### PR TITLE
Add default look-back period configuration and update query execution…

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ The configuration file is in JSON format with the following structure:
 {
     "api_key": "YOUR_URLSCAN_API_KEY",
     "output_directory": "output",
+    "default_days": 7,
     "queries": {
         "query-name": {
             "description": "Description of the query",
@@ -99,6 +100,13 @@ The configuration file is in JSON format with the following structure:
     }
 }
 ```
+
+### Configuration Options
+
+- `api_key`: Your urlscan.io API key for accessing the API.
+- `output_directory`: Directory to store reports and screenshots.
+- `default_days`: Default number of days to limit the search to if the `--days` flag is not specified. This prevents exceeding API limits by default.
+- `queries`: A map of named queries to execute against urlscan.io.
 
 ### Query Examples
 
@@ -137,6 +145,10 @@ output/
 ```
 
 ## Changelog
+
+### Version 0.1.2 (April 19, 2025)
+- Added configurable default look-back period via `default_days` in config
+- Query results now automatically use the default look-back period if `--days` flag is not specified
 
 ### Version 0.1.1 (April 18, 2025)
 - Added `-d/--days` flag to limit search results to a specific number of days

--- a/config.example.json
+++ b/config.example.json
@@ -1,6 +1,7 @@
 {
     "api_key": "YOUR_URLSCAN_API_KEY_HERE",
     "output_directory": "output",
+    "default_days": 7,
     "queries": {
         "usaa-domain": {
             "description": "Monitoring for scan tasks that have 'usaa' in the domain",

--- a/masq_monitor.py
+++ b/masq_monitor.py
@@ -146,13 +146,16 @@ def main():
     
     monitor = MasqMonitor(config_path=args.config)
     
+    # Use default_days from config if --days not specified
+    days = args.days if args.days is not None else monitor.config.get("default_days")
+    
     if args.list:
         monitor.list_queries()
     elif args.query:
-        monitor.run_query(args.query, days=args.days)
+        monitor.run_query(args.query, days=days)
     elif args.all:
         for query_name in monitor.config.get("queries", {}):
-            monitor.run_query(query_name, days=args.days)
+            monitor.run_query(query_name, days=days)
     else:
         parser.print_help()
 


### PR DESCRIPTION
… logic

- Introduced `default_days` option in configuration files to limit search results.
- Updated query execution to utilize `default_days` if `--days` flag is not specified.

Resolves #11 